### PR TITLE
Fix of pwm.py to work with the new sysfs on V3b

### DIFF
--- a/pcduino/gpio.py
+++ b/pcduino/gpio.py
@@ -1,4 +1,5 @@
 from pinmap import PinMap
+import os.path
 
 
 __all__ = ['HIGH', 'LOW', 'INPUT', 'OUTPUT','digital_write', 'digital_read',
@@ -35,6 +36,14 @@ def digital_read(channel):
 
 def pin_mode(channel, mode):
     """ Set Mode of a GPIO channel """
+
+    # has to disable new sysfs pwm
+    pwmPath = '/sys/class/misc/pwmtimer/enable/'
+    ending = 'pwm' + str(channel)
+    if os.path.isfile(os.path.join(pwmPath ,ending)):
+        with open(os.path.join(pwmPath, ending), 'w+') as f:
+            f.write('0')
+
     path = gpio_mode_pins.get_path(channel)
     with open(path, 'w+') as f:
         f.write('0' if mode == INPUT else '1')

--- a/pcduino/pwm.py
+++ b/pcduino/pwm.py
@@ -1,11 +1,5 @@
 import os.path
-
-#from pinmap import PinMap
-
-
-#pins = PinMap('/sys/devices/virtual/misc/pwmtimer/', 'pwm', 12)
-
-#pinMap broken beyond repair for new sysfs-pwm
+from os import listdir
 
 MAX_PWM_LEVEL = 255
 
@@ -15,26 +9,30 @@ def analog_write(pin, value):
     value can be an number between 0 and 255.
 
     """
+
     path = '/sys/class/misc/pwmtimer/'
 
     ending = 'pwm' + str(pin)
 
-    with open(os.path.join(path, 'max_level',ending )) as f:
+    pins = listdir(os.path.join(path, 'enable'))
+    if not ending in pins:
+        raise ValueError("Pin not found, PWM only possible on " + " ".join(str(p) for p in pins) + ".")
+
+    with open(os.path.join(path, 'max_level',ending)) as f:
         max_value = int(f.read())
 
     if value < 0 or value > MAX_PWM_LEVEL:
         raise ValueError("value must be between 0 and %s" % MAX_PWM_LEVEL)
 
     map_level = ((max_value-1) * value) // MAX_PWM_LEVEL
-	#// because python 3 compatibility
-   	#-1 because if it puts max_value the duty cycle somehow becomes 0 
- 
+   	#-1 because if it puts max_value the duty cycle somehow becomes 0 (overflow)
+
     #disable -> change level -> enable , as requested by documentation
     with open(os.path.join(path, 'enable', ending), 'w+') as f:
-        f.write("0\n")   
-    
+        f.write("0\n")
+
     with open(os.path.join(path, 'level', ending), 'w+') as f:
         f.write("%d\n" % map_level)
-    
+
     with open(os.path.join(path, 'enable', ending), 'w+') as f:
-        f.write("1\n")    
+        f.write("1\n")

--- a/pcduino/pwm.py
+++ b/pcduino/pwm.py
@@ -1,9 +1,11 @@
 import os.path
 
-from pinmap import PinMap
+#from pinmap import PinMap
 
 
-pins = PinMap('/sys/class/leds', 'pwm', 5)
+#pins = PinMap('/sys/devices/virtual/misc/pwmtimer/', 'pwm', 12)
+
+#pinMap broken beyond repair for new sysfs-pwm
 
 MAX_PWM_LEVEL = 255
 
@@ -13,14 +15,26 @@ def analog_write(pin, value):
     value can be an number between 0 and 255.
 
     """
-    path = pins.get_path(pin)
+    path = '/sys/class/misc/pwmtimer/'
 
-    with open(os.path.join(path, 'max_brightness')) as f:
+    ending = 'pwm' + str(pin)
+
+    with open(os.path.join(path, 'max_level',ending )) as f:
         max_value = int(f.read())
 
     if value < 0 or value > MAX_PWM_LEVEL:
         raise ValueError("value must be between 0 and %s" % MAX_PWM_LEVEL)
 
-    map_level = (max_value * value) / MAX_PWM_LEVEL
-    with open(os.path.join(path, 'brightness'), 'w+') as f:
+    map_level = (max_value * value) // MAX_PWM_LEVEL
+	#// because python 3 compatibility
+   	#for some reason 255 becomes 0 (overflow?)
+ 
+    #disable -> change level -> enable , as requested by documentation
+    with open(os.path.join(path, 'enable', ending), 'w+') as f:
+        f.write("0\n")   
+    
+    with open(os.path.join(path, 'level', ending), 'w+') as f:
         f.write("%d\n" % map_level)
+    
+    with open(os.path.join(path, 'enable', ending), 'w+') as f:
+        f.write("1\n")    

--- a/pcduino/pwm.py
+++ b/pcduino/pwm.py
@@ -25,9 +25,9 @@ def analog_write(pin, value):
     if value < 0 or value > MAX_PWM_LEVEL:
         raise ValueError("value must be between 0 and %s" % MAX_PWM_LEVEL)
 
-    map_level = (max_value * value) // MAX_PWM_LEVEL
+    map_level = ((max_value-1) * value) // MAX_PWM_LEVEL
 	#// because python 3 compatibility
-   	#for some reason 255 becomes 0 (overflow?)
+   	#-1 because if it puts max_value the duty cycle somehow becomes 0 
  
     #disable -> change level -> enable , as requested by documentation
     with open(os.path.join(path, 'enable', ending), 'w+') as f:

--- a/pcduino/testSkriptPwm.py
+++ b/pcduino/testSkriptPwm.py
@@ -1,0 +1,4 @@
+from pwm import analog_write
+
+analog_write(1,100)
+

--- a/pcduino/testSkriptPwm.py
+++ b/pcduino/testSkriptPwm.py
@@ -1,4 +1,0 @@
-from pwm import analog_write
-
-analog_write(1,100)
-


### PR DESCRIPTION
Hi,
I fixed the pwm-module to work on my PcDuino V3B with it's new sysfs, however I'm unable to test it on other PcDuinos, I'll leave that to you.
I'm pretty new to Git so feel free to disregard the intermediate commits, it should have been one commit.

Edit: I just added the  fourth commit, that adjusts the gpio module to disable pwm before using pin_mode, otherwise digital_write has no effect.