### PR TITLE
python 3 compatibility

### DIFF
--- a/pcduino/__init__.py
+++ b/pcduino/__init__.py
@@ -1,3 +1,3 @@
-from gpio import *
-from adc import analog_read
-from pwm import analog_write
+from pcduino.gpio import *
+from pcduino.adc import analog_read
+from pcduino.pwm import analog_write

--- a/pcduino/adc.py
+++ b/pcduino/adc.py
@@ -1,4 +1,4 @@
-from pinmap import PinMap
+from pcduino.pinmap import PinMap
 
 pins = PinMap('/proc', 'adc', 6)
 

--- a/pcduino/gpio.py
+++ b/pcduino/gpio.py
@@ -1,4 +1,4 @@
-from pinmap import PinMap
+from pcduino.pinmap import PinMap
 import os.path
 
 

--- a/pcduino/pinmap.py
+++ b/pcduino/pinmap.py
@@ -10,7 +10,7 @@ class InvalidChannelException(ValueError):
 
 class PinMap(object):
     def __init__(self, path, prefix, count):
-        self.pins = ['%s%s' % (prefix, i) for i in xrange(count)]
+        self.pins = ['%s%s' % (prefix, i) for i in range(count)]
         self.path = path
 
     def get_path(self, pin, path=None):


### PR DESCRIPTION
Replaced xrange with range in pinmap (range is very low, shouldn't
affect performance noticeably), changed relative imports to absolute
imports (PEP 328).